### PR TITLE
xacro fixes

### DIFF
--- a/motoman_ar2010_support/urdf/ar2010.xacro
+++ b/motoman_ar2010_support/urdf/ar2010.xacro
@@ -2,7 +2,7 @@
 
 <robot name="motoman_ar2010" xmlns:xacro="http://ros.org/wiki/xacro">
 	<xacro:include filename="$(find motoman_ar2010_support)/urdf/ar2010_macro.xacro" />
-	<xacro:property name="kinematics_offsets" value="${load_yaml('$(find motoman_ar2010_support)' + '/config/default_kinematic_offsets.yaml')}"/>
+	<xacro:property name="kinematics_offsets" value="${xacro.load_yaml('$(find motoman_ar2010_support)' + '/config/default_kinematic_offsets.yaml')}"/>
 	<xacro:motoman_ar2010 prefix="" kinematic_offsets="${kinematics_offsets['kinematic_offsets']}"/>
 </robot>
 

--- a/motoman_gp180_support/urdf/gp180.xacro
+++ b/motoman_gp180_support/urdf/gp180.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <robot name="motoman_gp180" xmlns:xacro="http://ros.org/wiki/xacro">
     <xacro:include filename="$(find motoman_gp180_support)/urdf/gp180_macro.xacro" />
-    <xacro:property name="kinematics_offsets" value="${load_yaml('$(find motoman_gp180_support)' + '/config/default_kinematic_offsets.yaml')}"/>
+    <xacro:property name="kinematics_offsets" value="${xacro.load_yaml('$(find motoman_gp180_support)' + '/config/default_kinematic_offsets.yaml')}"/>
     <xacro:motoman_gp180 prefix="" kinematic_offsets="${kinematics_offsets['kinematic_offsets']}"/>
 </robot>

--- a/motoman_gp20hl_support/urdf/gp20hl.xacro
+++ b/motoman_gp20hl_support/urdf/gp20hl.xacro
@@ -2,7 +2,7 @@
 
 <robot name="motoman_gp20hl" xmlns:xacro="http://ros.org/wiki/xacro">
 	<xacro:include filename="$(find motoman_gp20hl_support)/urdf/gp20hl_macro.xacro" />
-	<xacro:property name="kinematics_offsets" value="${load_yaml('$(find motoman_gp20hl_support)' + '/config/default_kinematic_offsets.yaml')}"/>
+	<xacro:property name="kinematics_offsets" value="${xacro.load_yaml('$(find motoman_gp20hl_support)' + '/config/default_kinematic_offsets.yaml')}"/>
 	<xacro:motoman_gp20hl prefix="" kinematic_offsets="${kinematics_offsets['kinematic_offsets']}"/>
 </robot>
 

--- a/motoman_motopos_d500_support/urdf/motopos_d500.xacro
+++ b/motoman_motopos_d500_support/urdf/motopos_d500.xacro
@@ -7,6 +7,6 @@
   </material>
   
   <xacro:include filename="$(find motoman_motopos_d500_support)/urdf/motopos_d500_macro.xacro" />
-  <xacro:property name="kinematics_offsets" value="${load_yaml('$(find motoman_motopos_d500_support)' + '/config/default_kinematic_offsets.yaml')}"/>
+  <xacro:property name="kinematics_offsets" value="${xacro.load_yaml('$(find motoman_motopos_d500_support)' + '/config/default_kinematic_offsets.yaml')}"/>
   <xacro:motoman_motopos_d500 prefix="" kinematic_offsets="${kinematics_offsets['kinematic_offsets']}"/>
 </robot>

--- a/motoman_motopos_mh1655_support/urdf/motopos_mh1655.xacro
+++ b/motoman_motopos_mh1655_support/urdf/motopos_mh1655.xacro
@@ -7,6 +7,6 @@
   </material>
 
   <xacro:include filename="$(find motoman_motopos_mh1655_support)/urdf/motopos_mh1655_macro.xacro" />
-  <xacro:property name="kinematics_offsets" value="${load_yaml('$(find motoman_motopos_mh1655_support)' + '/config/default_kinematic_offsets.yaml')}"/>
+  <xacro:property name="kinematics_offsets" value="${xacro.load_yaml('$(find motoman_motopos_mh1655_support)' + '/config/default_kinematic_offsets.yaml')}"/>
   <xacro:motoman_motopos_mh1655 prefix="" use_pedestal="false" kinematic_offsets="${kinematics_offsets['kinematic_offsets']}"/>
 </robot>


### PR DESCRIPTION
Fixes `load_yaml()` deprecated (introduced in new xacro update)

forge [PR#1290](https://github.com/path-robotics/forge/pull/1290)